### PR TITLE
Different width for viewer on narrow smartphone screens

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -141,7 +141,10 @@ body {
 @media only screen and (max-width: 812px){ /* This should catch smart phones with a screen width of, or narrower than, an iPhone X */
     #viewer {
         width: calc(100% - 60px);
-    }
+		height: calc(100% - 60px);
+        margin-top: 45px;
+        box-shadow: 0 0 5px rgba(0,0,0,.12), 0 5px 5px rgba(0,0,0,.24);
+	}
     .arrow span {
         font-size: 24px;
     }

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -138,6 +138,15 @@ body {
 	background-position: center;
 }
 
+@media only screen and (max-width: 812px){ /* This should catch smart phones with a screen width of, or narrower than, an iPhone X */
+    #viewer {
+        width: calc(100% - 60px);
+    }
+    .arrow span {
+        font-size: 24px;
+    }
+}
+
 /* #overlay {
     position: fixed;
     width: 100%;

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -140,13 +140,17 @@ body {
 
 @media only screen and (max-width: 812px){ /* This should catch smart phones with a screen width of, or narrower than, an iPhone X */
     #viewer {
-        width: calc(100% - 60px);
-		height: calc(100% - 60px);
-        margin-top: 45px;
+        width: calc(100% - 80px);
+        height: calc(100% - 60px);
+        margin-top: 40px;
         box-shadow: 0 0 5px rgba(0,0,0,.12), 0 5px 5px rgba(0,0,0,.24);
-	}
+    }
     .arrow span {
         font-size: 24px;
+    }
+    #divider {
+        margin-top: 40px;
+        height: calc(100% - 60px);
     }
 }
 


### PR DESCRIPTION
Here is a first go at improving the screen width of pages on smart phones.  The width is detected as for an iPhone X or lower.  I've tested this on my Samsung Galaxy A53 5G and it works ok - cover page is visible and it is possible to turn the pages and see the text.